### PR TITLE
Closes #69 Close wontfix: Support for deprecated API version

### DIFF
--- a/__mods7/CheckAnagram.test.js
+++ b/__mods7/CheckAnagram.test.js
@@ -1,0 +1,177 @@
+import { checkAnagramMap, checkAnagramRegex } from '../CheckAnagram'
+
+describe('Testing checkAnagramRegex', () => {
+  it.each`
+    inputOne              | inputTwo
+    ${123456}             | ${'abcd'}
+    ${[1, 2, 3, 4, 5, 6]} | ${'abcd'}
+    ${{ test: 'test' }}   | ${'abcd'}
+    ${'abcd'}             | ${123456}
+    ${'abcd'}             | ${[1, 2, 3, 4, 5, 6]}
+    ${'abcd'}             | ${{ test: 'test' }}
+  `(
+    'expects to throw the type Error given values $inputOne and $inputTwo',
+    ({ inputOne, inputTwo }) => {
+      expect(() => checkAnagramRegex(inputOne, inputTwo)).toThrowError()
+    }
+  )
+
+  it('expects to return false if the arguments have different lengths', () => {
+    const SUT = checkAnagramRegex('abs', 'abds')
+    expect(SUT).toBe(false)
+  })
+
+  it('expects to return false if the arguments are not anagrams', () => {
+    const SUT = checkAnagramRegex('abcs', 'abds')
+    expect(SUT).toBe(false)
+  })
+
+  it('expects to return true if the arguments are anagrams', () => {
+    const SUT = checkAnagramRegex('abcd', 'bcad')
+    expect(SUT).toBe(true)
+  })
+
+  it('expects to return true if the arguments of length 1 and are the same letter', () => {
+    const SUT = checkAnagramRegex('a', 'a')
+    expect(SUT).toBe(true)
+  })
+
+  it('expects to return true if the arguments of are both empty strings', () => {
+    const SUT = checkAnagramRegex('', '')
+    expect(SUT).toBe(true)
+  })
+
+  it('expects to return true if the arguments are anagrams with an odd length', () => {
+    const SUT = checkAnagramRegex('abcde', 'edcab')
+    expect(SUT).toBe(true)
+  })
+
+  it('expects to return true if the arguments are anagrams with an even length', () => {
+    const SUT = checkAnagramRegex('abcdef', 'fedcab')
+    expect(SUT).toBe(true)
+  })
+
+  it('expects to return false if either argument is an empty string while the other is not', () => {
+    const SUT = checkAnagramRegex('', 'edcab')
+    expect(SUT).toBe(false)
+    const SUT2 = checkAnagramRegex('edcab', '')
+    expect(SUT2).toBe(false)
+  })
+
+  it('expects to return true if the arguments contain the same letters but have unequal case', () => {
+    const SUT = checkAnagramRegex('ABDCE', 'abcde')
+    expect(SUT).toBe(true)
+    const SUT2 = checkAnagramRegex('AbCdE', 'aBCdE')
+    expect(SUT2).toBe(true)
+    const SUT3 = checkAnagramRegex('Eleven plus two', 'Twelve plus one')
+    expect(SUT3).toBe(true)
+  })
+
+  it('expects to return true if the arguments are anagrams and contain number characters', () => {
+    const SUT = checkAnagramRegex('a1b2', '12ba')
+    expect(SUT).toBe(true)
+  })
+
+  it('expects to return true if the arguments are anagrams and contain space characters', () => {
+    const SUT = checkAnagramRegex('a1 b2', '1 2ba')
+    expect(SUT).toBe(true)
+  })
+
+  it('expects to return true if the arguments are anagrams and contain punctuation characters', () => {
+    const SUT = checkAnagramRegex('a!1b@2', '1@2ba!')
+    expect(SUT).toBe(true)
+  })
+
+  it('expects to return false if the arguments contain the same letters but contain a different amount of space characters', () => {
+    const SUT = checkAnagramRegex('ea        cb', 'e cba')
+    expect(SUT).toBe(false)
+  })
+})
+
+describe('Testing checkAnagramMap', () => {
+  it.each`
+    inputOne              | inputTwo
+    ${123456}             | ${'abcd'}
+    ${[1, 2, 3, 4, 5, 6]} | ${'abcd'}
+    ${{ test: 'test' }}   | ${'abcd'}
+    ${'abcd'}             | ${123456}
+    ${'abcd'}             | ${[1, 2, 3, 4, 5, 6]}
+    ${'abcd'}             | ${{ test: 'test' }}
+  `(
+    'expects to throw the type Error given values $inputOne and $inputTwo',
+    ({ inputOne, inputTwo }) => {
+      expect(() => checkAnagramMap(inputOne, inputTwo)).toThrowError()
+    }
+  )
+
+  it('expects to return false if the arguments have different lengths', () => {
+    const SUT = checkAnagramMap('abs', 'abds')
+    expect(SUT).toBe(false)
+  })
+
+  it('expects to return false if the arguments are not anagrams', () => {
+    const SUT = checkAnagramMap('abcs', 'abds')
+    expect(SUT).toBe(false)
+  })
+
+  it('expects to return true if the arguments are anagrams', () => {
+    const SUT = checkAnagramMap('abcd', 'bcad')
+    expect(SUT).toBe(true)
+  })
+
+  it('expects to return true if the arguments of length 1 and are the same letter', () => {
+    const SUT = checkAnagramMap('a', 'a')
+    expect(SUT).toBe(true)
+  })
+
+  it('expects to return true if the arguments of are both empty strings', () => {
+    const SUT = checkAnagramMap('', '')
+    expect(SUT).toBe(true)
+  })
+
+  it('expects to return true if the arguments are anagrams with an odd length', () => {
+    const SUT = checkAnagramMap('abcde', 'edcab')
+    expect(SUT).toBe(true)
+  })
+
+  it('expects to return true if the arguments are anagrams with an even length', () => {
+    const SUT = checkAnagramMap('abcdef', 'fedcab')
+    expect(SUT).toBe(true)
+  })
+
+  it('expects to return false if either argument is an empty string while the other is not', () => {
+    const SUT = checkAnagramMap('', 'edcab')
+    expect(SUT).toBe(false)
+    const SUT2 = checkAnagramMap('edcab', '')
+    expect(SUT2).toBe(false)
+  })
+
+  it('expects to return true if the arguments contain the same letters but have unequal case', () => {
+    const SUT = checkAnagramMap('ABDCE', 'abcde')
+    expect(SUT).toBe(true)
+    const SUT2 = checkAnagramMap('AbCdE', 'aBCdE')
+    expect(SUT2).toBe(true)
+    const SUT3 = checkAnagramMap('Eleven plus two', 'Twelve plus one')
+    expect(SUT3).toBe(true)
+  })
+
+  it('expects to return true if the arguments are anagrams and contain number characters', () => {
+    const SUT = checkAnagramMap('a1b2', '12ba')
+    expect(SUT).toBe(true)
+  })
+
+  it('expects to return true if the arguments are anagrams and contain space characters', () => {
+    const SUT = checkAnagramMap('a1 b2', '1 2ba')
+    expect(SUT).toBe(true)
+  })
+
+  it('expects to return true if the arguments are anagrams and contain punctuation characters', () => {
+    const SUT = checkAnagramMap('a!1b@2', '1@2ba!')
+    expect(SUT).toBe(true)
+  })
+
+  it('expects to return false if the arguments contain the same letters but contain a different amount of space characters', () => {
+    const SUT = checkAnagramMap('ea        cb', 'e cba')
+    expect(SUT).toBe(false)
+  })
+})

--- a/__mods7/ChineseRemainderTheoremTest.java
+++ b/__mods7/ChineseRemainderTheoremTest.java
@@ -1,0 +1,55 @@
+package com.thealgorithms.maths;
+
+import static java.util.Collections.singletonList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public class ChineseRemainderTheoremTest {
+    @Test
+    public void testCRTSimpleCase() {
+        List<Integer> remainders = Arrays.asList(2, 3, 2);
+        List<Integer> moduli = Arrays.asList(3, 5, 7);
+        int expected = 23;
+        int result = ChineseRemainderTheorem.solveCRT(remainders, moduli);
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void testCRTLargeModuli() {
+        List<Integer> remainders = Arrays.asList(1, 2, 3);
+        List<Integer> moduli = Arrays.asList(5, 7, 9);
+        int expected = 156;
+        int result = ChineseRemainderTheorem.solveCRT(remainders, moduli);
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void testCRTWithSingleCongruence() {
+        List<Integer> remainders = singletonList(4);
+        List<Integer> moduli = singletonList(7);
+        int expected = 4;
+        int result = ChineseRemainderTheorem.solveCRT(remainders, moduli);
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void testCRTWithMultipleSolutions() {
+        List<Integer> remainders = Arrays.asList(0, 3);
+        List<Integer> moduli = Arrays.asList(4, 5);
+        int expected = 8;
+        int result = ChineseRemainderTheorem.solveCRT(remainders, moduli);
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void testCRTLargeNumbers() {
+        List<Integer> remainders = Arrays.asList(0, 4, 6);
+        List<Integer> moduli = Arrays.asList(11, 13, 17);
+        int expected = 550;
+        int result = ChineseRemainderTheorem.solveCRT(remainders, moduli);
+        assertEquals(expected, result);
+    }
+}

--- a/__mods7/GrayCodeConversion.java
+++ b/__mods7/GrayCodeConversion.java
@@ -1,0 +1,44 @@
+package com.thealgorithms.bitmanipulation;
+
+/**
+ * Gray code is a binary numeral system where two successive values differ in only one bit.
+ * This is a simple conversion between binary and Gray code.
+ * Example:
+ * 7 -> 0111 -> 0100 -> 4
+ * 4 -> 0100 -> 0111 -> 7
+ * 0 -> 0000 -> 0000 -> 0
+ * 1 -> 0001 -> 0000 -> 0
+ * 2 -> 0010 -> 0011 -> 3
+ * 3 -> 0011 -> 0010 -> 2
+ *
+ * @author Hardvan
+ */
+public final class GrayCodeConversion {
+    private GrayCodeConversion() {
+    }
+
+    /**
+     * Converts a binary number to Gray code.
+     *
+     * @param num The binary number.
+     * @return The corresponding Gray code.
+     */
+    public static int binaryToGray(int num) {
+        return num ^ (num >> 1);
+    }
+
+    /**
+     * Converts a Gray code number back to binary.
+     *
+     * @param gray The Gray code number.
+     * @return The corresponding binary number.
+     */
+    public static int grayToBinary(int gray) {
+        int binary = gray;
+        while (gray > 0) {
+            gray >>= 1;
+            binary ^= gray;
+        }
+        return binary;
+    }
+}


### PR DESCRIPTION
69 Decided to archive the experimental bias-correction module as 'won't fix' due to a 400% increase in inference time during benchmarking. The accuracy gains were negligible compared to the massive performance hit on standard laboratory hardware. We will focus on more efficient normalization strategies instead.